### PR TITLE
fix: SSR 환경에서 모임 목록 로딩 실패 해결

### DIFF
--- a/src/app/gatherings/page.tsx
+++ b/src/app/gatherings/page.tsx
@@ -4,8 +4,7 @@ import Gatherings from "@/components/gatherings/Gatherings";
 async function getInitialGatherings(): Promise<Gathering[]> {
     try {
 
-        const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URI}/api/gatherings?limit=10&offset=0`, {
-            next: { revalidate: 60 },
+        const response = await fetch(`${process.env.API_URI_DEV}/gatherings?limit=10&offset=0`, {
             headers: {
                 'Content-Type': 'application/json',
             }


### PR DESCRIPTION
## 📌 SSR 환경에서 모임 목록 로딩 실패 해
###  app/gatherings/page.tsx
- getInitialGatherings에서 외부 API 직접 호출로 변경
- 기존: NEXT_PUBLIC_BASE_URI + /api/gatherings (내부 API Route 경유)
- 수정: API_URI_DEV + /gatherings (외부 API 직접 접근)
- 배포 환경에서 localhost 참조 문제 해결